### PR TITLE
Fix/latency

### DIFF
--- a/config/fairyboard.keymap
+++ b/config/fairyboard.keymap
@@ -21,7 +21,7 @@
 //--------------------------------------------------------------------------------------------------
 // Global defines
 
-#define PHT_TAPPING_TERM_MS     600  // Positional hold tap tapping term (ms)
+#define PHT_TAPPING_TERM_MS     280  // Positional hold tap tapping term (ms)
 #define PHT_IDLE_MS             200  // Positional hold tap require idle time (ms)
 #define LT_TAPPING_TERM_MS      200  // Layer tap tapping term (ms)
 #define MOD_TOG_TAPPING_TERM_MS 200  // Mod tap tapping term (ms)
@@ -30,7 +30,7 @@
 #define COMBO_TERM_FAST_MS       25  // Fast combo term for horizontal combos (ms)
 #define COMBO_TERM_SLOW_MS      100  // Slow combo term for vertical combos (ms)
 #define COMBO_IDLE_FAST_MS       50  // Fast require prior idle time for horizontal combos (ms)
-#define COMBO_IDLE_SLOW_MS        0  // Slow require prior idle time for vertical combos (ms)
+#define COMBO_IDLE_SLOW_MS      100  // Slow require prior idle time for vertical combos (ms)
 
 #define NONE 0  // Null keypress
 

--- a/images/fairyboard.svg
+++ b/images/fairyboard.svg
@@ -68,25 +68,25 @@ text.footer {
 }
 
 /* styling for combo tap, and key non-tap label text */
-text.combo, text.hold, text.shifted, text.left, text.right {
+text.combo, text.hold, text.shifted, text.left, text.right, text.tl, text.tr, text.bl, text.br {
     font-size: 11px;
 }
 
-text.hold {
+text.hold, text.bl, text.br {
     text-anchor: middle;
     dominant-baseline: auto;
 }
 
-text.shifted {
+text.shifted, text.tl, text.tr {
     text-anchor: middle;
     dominant-baseline: hanging;
 }
 
-text.left {
+text.left, text.tl, text.bl {
     text-anchor: start;
 }
 
-text.right {
+text.right, text.tr, text.br {
     text-anchor: end;
 }
 
@@ -813,7 +813,7 @@ path.combo { stroke: #7f7f7f; }
 <g transform="translate(861, 97) rotate(-14.0)" class="key keypos-23">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-1.2em">RIGHT</tspan><tspan x="0" dy="1.2em">ALT</tspan>
+<tspan x="0" dy="-0.9em">RIGHT</tspan><tspan x="0" dy="1.2em">ALT</tspan>
 </text>
 <text x="0" y="24" class="key hold">sticky</text>
 </g>
@@ -990,7 +990,7 @@ path.combo { stroke: #7f7f7f; }
 <g transform="translate(861, 97) rotate(-14.0)" class="key keypos-23">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-1.2em">RIGHT</tspan><tspan x="0" dy="1.2em">ALT</tspan>
+<tspan x="0" dy="-0.9em">RIGHT</tspan><tspan x="0" dy="1.2em">ALT</tspan>
 </text>
 <text x="0" y="24" class="key hold">sticky</text>
 </g>
@@ -1123,7 +1123,7 @@ path.combo { stroke: #7f7f7f; }
 <g transform="translate(34, 97) rotate(14.0)" class="key keypos-12">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-1.2em">RIGHT</tspan><tspan x="0" dy="1.2em">ALT</tspan>
+<tspan x="0" dy="-0.9em">RIGHT</tspan><tspan x="0" dy="1.2em">ALT</tspan>
 </text>
 <text x="0" y="24" class="key hold">sticky</text>
 </g>
@@ -1309,7 +1309,7 @@ path.combo { stroke: #7f7f7f; }
 <g transform="translate(34, 97) rotate(14.0)" class="key keypos-12">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-1.2em">RIGHT</tspan><tspan x="0" dy="1.2em">ALT</tspan>
+<tspan x="0" dy="-0.9em">RIGHT</tspan><tspan x="0" dy="1.2em">ALT</tspan>
 </text>
 <text x="0" y="24" class="key hold">sticky</text>
 </g>
@@ -1547,7 +1547,7 @@ path.combo { stroke: #7f7f7f; }
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <a href="#game-1">
 <text x="0" y="0" class="key tap layer-activator">
-<tspan x="0" dy="-1.2em">game</tspan><tspan x="0" dy="1.2em">1</tspan>
+<tspan x="0" dy="-0.9em">game</tspan><tspan x="0" dy="1.2em">1</tspan>
 </text>
 </a><text x="0" y="24" class="key hold">toggle</text>
 </g>

--- a/images/shockboard.svg
+++ b/images/shockboard.svg
@@ -68,25 +68,25 @@ text.footer {
 }
 
 /* styling for combo tap, and key non-tap label text */
-text.combo, text.hold, text.shifted, text.left, text.right {
+text.combo, text.hold, text.shifted, text.left, text.right, text.tl, text.tr, text.bl, text.br {
     font-size: 11px;
 }
 
-text.hold {
+text.hold, text.bl, text.br {
     text-anchor: middle;
     dominant-baseline: auto;
 }
 
-text.shifted {
+text.shifted, text.tl, text.tr {
     text-anchor: middle;
     dominant-baseline: hanging;
 }
 
-text.left {
+text.left, text.tl, text.bl {
     text-anchor: start;
 }
 
-text.right {
+text.right, text.tr, text.br {
     text-anchor: end;
 }
 
@@ -585,7 +585,7 @@ path.combo { stroke: #7f7f7f; }
 <g transform="translate(791, 159) rotate(-8.0)" class="key keypos-35">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-1.2em">RIGHT</tspan><tspan x="0" dy="1.2em">ALT</tspan>
+<tspan x="0" dy="-0.9em">RIGHT</tspan><tspan x="0" dy="1.2em">ALT</tspan>
 </text>
 <text x="0" y="24" class="key hold">sticky</text>
 </g>
@@ -789,7 +789,7 @@ path.combo { stroke: #7f7f7f; }
 <g transform="translate(791, 159) rotate(-8.0)" class="key keypos-35">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-1.2em">RIGHT</tspan><tspan x="0" dy="1.2em">ALT</tspan>
+<tspan x="0" dy="-0.9em">RIGHT</tspan><tspan x="0" dy="1.2em">ALT</tspan>
 </text>
 <text x="0" y="24" class="key hold">sticky</text>
 </g>
@@ -961,7 +961,7 @@ path.combo { stroke: #7f7f7f; }
 <g transform="translate(32, 159) rotate(8.0)" class="key keypos-24">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-1.2em">RIGHT</tspan><tspan x="0" dy="1.2em">ALT</tspan>
+<tspan x="0" dy="-0.9em">RIGHT</tspan><tspan x="0" dy="1.2em">ALT</tspan>
 </text>
 <text x="0" y="24" class="key hold">sticky</text>
 </g>
@@ -1192,7 +1192,7 @@ path.combo { stroke: #7f7f7f; }
 <g transform="translate(32, 159) rotate(8.0)" class="key keypos-24">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-1.2em">RIGHT</tspan><tspan x="0" dy="1.2em">ALT</tspan>
+<tspan x="0" dy="-0.9em">RIGHT</tspan><tspan x="0" dy="1.2em">ALT</tspan>
 </text>
 <text x="0" y="24" class="key hold">sticky</text>
 </g>


### PR DESCRIPTION
Add a 0.1s delay before number combo fires and lower positional hold-tap tapping term to match urob's, preventing homerow mod misfires