### PR TITLE
Fix/ble profiles

### DIFF
--- a/config/fairyboard.conf
+++ b/config/fairyboard.conf
@@ -13,6 +13,11 @@ CONFIG_ZMK_IDLE_TIMEOUT=30000
 CONFIG_ZMK_SLEEP=y
 CONFIG_ZMK_IDLE_SLEEP_TIMEOUT=900000
 
+# Settings
+# Default is 60000, which loses the active BLE profile and preferred endpoint if
+# the board deep sleeps or soft offs before the write lands.
+CONFIG_ZMK_SETTINGS_SAVE_DEBOUNCE=5000
+
 # Bluetooth
 CONFIG_BT_CTLR_TX_PWR_PLUS_8=y
 CONFIG_ZMK_BLE_EXPERIMENTAL_CONN=y

--- a/config/fairyboard.keymap
+++ b/config/fairyboard.keymap
@@ -257,7 +257,7 @@
         bt_sel_0: bt_sel_0 {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            bindings = <&bt BT_SEL 0>;
+            bindings = <&out OUT_BLE>, <&bt BT_SEL 0>;
         };
 
         bt_disc_0: bt_disc_0 {
@@ -269,7 +269,7 @@
         bt_sel_1: bt_sel_1 {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            bindings = <&bt BT_SEL 1>;
+            bindings = <&out OUT_BLE>, <&bt BT_SEL 1>;
         };
 
         bt_disc_1: bt_disc_1 {
@@ -281,7 +281,7 @@
         bt_sel_2: bt_sel_2 {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            bindings = <&bt BT_SEL 2>;
+            bindings = <&out OUT_BLE>, <&bt BT_SEL 2>;
         };
 
         bt_disc_2: bt_disc_2 {
@@ -293,7 +293,7 @@
         bt_sel_3: bt_sel_3 {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            bindings = <&bt BT_SEL 3>;
+            bindings = <&out OUT_BLE>, <&bt BT_SEL 3>;
         };
 
         bt_disc_3: bt_disc_3 {
@@ -305,7 +305,7 @@
         bt_sel_4: bt_sel_4 {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            bindings = <&bt BT_SEL 4>;
+            bindings = <&out OUT_BLE>, <&bt BT_SEL 4>;
         };
 
         bt_disc_4: bt_disc_4 {
@@ -486,7 +486,7 @@
         set_layer {
             display-name = "set";
             bindings = <
-&soft_off  &none           &none           &none           &none           &bt BT_CLR      &none         &kp C_BRIGHTNESS_DEC  &kp C_BRIGHTNESS_INC  &out OUT_TOG  &kp PRINTSCREEN     &none
+&soft_off  &none           &none           &none           &none           &bt BT_CLR      &none         &kp C_BRIGHTNESS_DEC  &kp C_BRIGHTNESS_INC  &out OUT_USB  &kp PRINTSCREEN     &none
 &none      &bt_hold_0 0 0  &bt_hold_1 0 0  &bt_hold_2 0 0  &bt_hold_3 0 0  &bt_hold_4 0 0  &none         &kp C_VOLUME_DOWN     &kp C_VOLUME_UP       &kp C_MUTE    &none               &kp INSERT
            &to GAME        &none           &none           &none           &bootloader     &kp C_REWIND  &kp C_PREVIOUS        &kp C_PLAY_PAUSE      &kp C_NEXT    &kp C_FAST_FORWARD
                                            &none           &none           &none           &none         &none                 &none

--- a/config/fairyboard.keymap
+++ b/config/fairyboard.keymap
@@ -509,10 +509,10 @@
         set_layer {
             display-name = "set";
             bindings = <
-&soft_off  &none           &none           &none           &none           &bt_clr_hold 0 0  &none         &kp C_BRIGHTNESS_DEC  &kp C_BRIGHTNESS_INC  &out_hold OUT_BLE OUT_USB  &kp PRINTSCREEN     &none
-&none      &bt_hold_0 0 0  &bt_hold_1 0 0  &bt_hold_2 0 0  &bt_hold_3 0 0  &bt_hold_4 0 0    &none         &kp C_VOLUME_DOWN     &kp C_VOLUME_UP       &kp C_MUTE                 &none               &kp INSERT
-           &to GAME        &none           &none           &none           &bootloader       &kp C_REWIND  &kp C_PREVIOUS        &kp C_PLAY_PAUSE      &kp C_NEXT                 &kp C_FAST_FORWARD
-                                           &none           &none           &none             &none         &none                 &none
+&soft_off         &none           &none           &none           &none           &out_hold OUT_BLE OUT_USB  &none         &kp C_BRIGHTNESS_DEC  &kp C_BRIGHTNESS_INC  &none       &kp PRINTSCREEN     &none
+&bt_clr_hold 0 0  &bt_hold_0 0 0  &bt_hold_1 0 0  &bt_hold_2 0 0  &bt_hold_3 0 0  &bt_hold_4 0 0             &none         &kp C_VOLUME_DOWN     &kp C_VOLUME_UP       &kp C_MUTE  &none               &kp INSERT
+                  &to GAME        &none           &none           &none           &bootloader                &kp C_REWIND  &kp C_PREVIOUS        &kp C_PLAY_PAUSE      &kp C_NEXT  &kp C_FAST_FORWARD
+                                                  &none           &none           &none                      &none         &none                 &none
             >;
         };
     };

--- a/config/fairyboard.keymap
+++ b/config/fairyboard.keymap
@@ -26,6 +26,7 @@
 #define LT_TAPPING_TERM_MS      200  // Layer tap tapping term (ms)
 #define MOD_TOG_TAPPING_TERM_MS 200  // Mod tap tapping term (ms)
 #define QUICK_TAP_MS            225  // Quick tap timing (ms)
+#define LONG_HOLD_TERM_MS      3000  // Deliberate hold for output select and bond clear (ms)
 #define SK_RELEASE_AFTER_MS     900  // Release sticky key after (ms)
 #define COMBO_TERM_FAST_MS       25  // Fast combo term for horizontal combos (ms)
 #define COMBO_TERM_SLOW_MS      100  // Slow combo term for vertical combos (ms)
@@ -257,7 +258,7 @@
         bt_sel_0: bt_sel_0 {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            bindings = <&out OUT_BLE>, <&bt BT_SEL 0>;
+            bindings = <&bt BT_SEL 0>;
         };
 
         bt_disc_0: bt_disc_0 {
@@ -269,7 +270,7 @@
         bt_sel_1: bt_sel_1 {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            bindings = <&out OUT_BLE>, <&bt BT_SEL 1>;
+            bindings = <&bt BT_SEL 1>;
         };
 
         bt_disc_1: bt_disc_1 {
@@ -281,7 +282,7 @@
         bt_sel_2: bt_sel_2 {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            bindings = <&out OUT_BLE>, <&bt BT_SEL 2>;
+            bindings = <&bt BT_SEL 2>;
         };
 
         bt_disc_2: bt_disc_2 {
@@ -293,7 +294,7 @@
         bt_sel_3: bt_sel_3 {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            bindings = <&out OUT_BLE>, <&bt BT_SEL 3>;
+            bindings = <&bt BT_SEL 3>;
         };
 
         bt_disc_3: bt_disc_3 {
@@ -305,13 +306,19 @@
         bt_sel_4: bt_sel_4 {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            bindings = <&out OUT_BLE>, <&bt BT_SEL 4>;
+            bindings = <&bt BT_SEL 4>;
         };
 
         bt_disc_4: bt_disc_4 {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
             bindings = <&bt BT_DISC 4>;
+        };
+
+        bt_clr: bt_clr {
+            compatible = "zmk,behavior-macro";
+            #binding-cells = <0>;
+            bindings = <&bt BT_CLR>;
         };
     };
 
@@ -371,6 +378,14 @@
             bindings = <&to BASE>, <&to SYM>, <&to FUN>;
         };
 
+        out_hold: out_hold {  // BLE output on hold, USB output on tap
+            compatible = "zmk,behavior-hold-tap";
+            #binding-cells = <2>;
+            bindings = <&out>, <&out>;
+            tapping-term-ms = <LONG_HOLD_TERM_MS>;
+            flavor = "tap-preferred";
+        };
+
         bt_hold_0: bt_hold_0 {  // Disconnect on hold, connect on tap
             compatible = "zmk,behavior-hold-tap";
             #binding-cells = <2>;
@@ -404,6 +419,14 @@
             #binding-cells = <2>;
             bindings = <&bt_disc_4>, <&bt_sel_4>;
             tapping-term-ms = <LT_TAPPING_TERM_MS>;
+        };
+
+        bt_clr_hold: bt_clr_hold {  // Clear the active profile bond on hold, nothing on tap
+            compatible = "zmk,behavior-hold-tap";
+            #binding-cells = <2>;
+            bindings = <&bt_clr>, <&none>;
+            tapping-term-ms = <LONG_HOLD_TERM_MS>;
+            flavor = "tap-preferred";
         };
     };
 
@@ -486,10 +509,10 @@
         set_layer {
             display-name = "set";
             bindings = <
-&soft_off  &none           &none           &none           &none           &bt BT_CLR      &none         &kp C_BRIGHTNESS_DEC  &kp C_BRIGHTNESS_INC  &out OUT_USB  &kp PRINTSCREEN     &none
-&none      &bt_hold_0 0 0  &bt_hold_1 0 0  &bt_hold_2 0 0  &bt_hold_3 0 0  &bt_hold_4 0 0  &none         &kp C_VOLUME_DOWN     &kp C_VOLUME_UP       &kp C_MUTE    &none               &kp INSERT
-           &to GAME        &none           &none           &none           &bootloader     &kp C_REWIND  &kp C_PREVIOUS        &kp C_PLAY_PAUSE      &kp C_NEXT    &kp C_FAST_FORWARD
-                                           &none           &none           &none           &none         &none                 &none
+&soft_off  &none           &none           &none           &none           &bt_clr_hold 0 0  &none         &kp C_BRIGHTNESS_DEC  &kp C_BRIGHTNESS_INC  &out_hold OUT_BLE OUT_USB  &kp PRINTSCREEN     &none
+&none      &bt_hold_0 0 0  &bt_hold_1 0 0  &bt_hold_2 0 0  &bt_hold_3 0 0  &bt_hold_4 0 0    &none         &kp C_VOLUME_DOWN     &kp C_VOLUME_UP       &kp C_MUTE                 &none               &kp INSERT
+           &to GAME        &none           &none           &none           &bootloader       &kp C_REWIND  &kp C_PREVIOUS        &kp C_PLAY_PAUSE      &kp C_NEXT                 &kp C_FAST_FORWARD
+                                           &none           &none           &none             &none         &none                 &none
             >;
         };
     };

--- a/images/fairyboard.svg
+++ b/images/fairyboard.svg
@@ -1457,9 +1457,7 @@ path.combo { stroke: #7f7f7f; }
 </g>
 <g transform="translate(324, 90) rotate(14.0)" class="key keypos-5">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em">BT</tspan><tspan x="0" dy="1.2em">CLR</tspan>
-</text>
+<text x="0" y="24" class="key hold">&amp;bt_clr</text>
 </g>
 <g transform="translate(571, 90) rotate(-14.0)" class="key keypos-6">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -1479,8 +1477,9 @@ path.combo { stroke: #7f7f7f; }
 <g transform="translate(730, 34) rotate(-14.0)" class="key keypos-9">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em">OUT</tspan><tspan x="0" dy="1.2em">USB</tspan>
+<tspan x="0" dy="-0.9em">OUT</tspan><tspan x="0" dy="1.2em">USB</tspan>
 </text>
+<text x="0" y="24" class="key hold">OUT BLE</text>
 </g>
 <g transform="translate(792, 50) rotate(-14.0)" class="key keypos-10">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>

--- a/images/fairyboard.svg
+++ b/images/fairyboard.svg
@@ -1479,7 +1479,7 @@ path.combo { stroke: #7f7f7f; }
 <g transform="translate(730, 34) rotate(-14.0)" class="key keypos-9">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em">OUT</tspan><tspan x="0" dy="1.2em">TOG</tspan>
+<tspan x="0" dy="-0.6em">OUT</tspan><tspan x="0" dy="1.2em">USB</tspan>
 </text>
 </g>
 <g transform="translate(792, 50) rotate(-14.0)" class="key keypos-10">

--- a/images/fairyboard.svg
+++ b/images/fairyboard.svg
@@ -1457,7 +1457,10 @@ path.combo { stroke: #7f7f7f; }
 </g>
 <g transform="translate(324, 90) rotate(14.0)" class="key keypos-5">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="24" class="key hold">&amp;bt_clr</text>
+<text x="0" y="0" class="key tap">
+<tspan x="0" dy="-0.9em">OUT</tspan><tspan x="0" dy="1.2em">USB</tspan>
+</text>
+<text x="0" y="24" class="key hold">OUT BLE</text>
 </g>
 <g transform="translate(571, 90) rotate(-14.0)" class="key keypos-6">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -1476,10 +1479,6 @@ path.combo { stroke: #7f7f7f; }
 </g>
 <g transform="translate(730, 34) rotate(-14.0)" class="key keypos-9">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.9em">OUT</tspan><tspan x="0" dy="1.2em">USB</tspan>
-</text>
-<text x="0" y="24" class="key hold">OUT BLE</text>
 </g>
 <g transform="translate(792, 50) rotate(-14.0)" class="key keypos-10">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -1490,6 +1489,7 @@ path.combo { stroke: #7f7f7f; }
 </g>
 <g transform="translate(34, 97) rotate(14.0)" class="key keypos-12">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="24" class="key hold">&amp;bt_clr</text>
 </g>
 <g transform="translate(90, 105) rotate(14.0)" class="key keypos-13">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>

--- a/images/fairyboard.yaml
+++ b/images/fairyboard.yaml
@@ -177,14 +177,14 @@ layers:
     - ''
     - ''
     - ''
-    - {h: '&bt_clr'}
+    - {t: OUT USB, h: OUT BLE}
     - ''
     - BRIGHTNESS DEC
     - BRIGHTNESS INC
-    - {t: OUT USB, h: OUT BLE}
+    - ''
     - PRINTSCREEN
     - ''
-  - - ''
+  - - {h: '&bt_clr'}
     - {t: '&bt_sel_0', h: '&bt_disc_0'}
     - {t: '&bt_sel_1', h: '&bt_disc_1'}
     - {t: '&bt_sel_2', h: '&bt_disc_2'}

--- a/images/fairyboard.yaml
+++ b/images/fairyboard.yaml
@@ -172,7 +172,18 @@ layers:
     - '0'
     - ENTER
   set:
-  - ['&soft_off', '', '', '', '', BT CLR, '', BRIGHTNESS DEC, BRIGHTNESS INC, OUT USB, PRINTSCREEN, '']
+  - - '&soft_off'
+    - ''
+    - ''
+    - ''
+    - ''
+    - {h: '&bt_clr'}
+    - ''
+    - BRIGHTNESS DEC
+    - BRIGHTNESS INC
+    - {t: OUT USB, h: OUT BLE}
+    - PRINTSCREEN
+    - ''
   - - ''
     - {t: '&bt_sel_0', h: '&bt_disc_0'}
     - {t: '&bt_sel_1', h: '&bt_disc_1'}

--- a/images/fairyboard.yaml
+++ b/images/fairyboard.yaml
@@ -172,7 +172,7 @@ layers:
     - '0'
     - ENTER
   set:
-  - ['&soft_off', '', '', '', '', BT CLR, '', BRIGHTNESS DEC, BRIGHTNESS INC, OUT TOG, PRINTSCREEN, '']
+  - ['&soft_off', '', '', '', '', BT CLR, '', BRIGHTNESS DEC, BRIGHTNESS INC, OUT USB, PRINTSCREEN, '']
   - - ''
     - {t: '&bt_sel_0', h: '&bt_disc_0'}
     - {t: '&bt_sel_1', h: '&bt_disc_1'}


### PR DESCRIPTION
The keyboard wouldn't default to using the USB after connected to bluetooth due to the use of `&out OUT_TOG` instead of `&out OUT_{BLE,USB}`.

This maps OUT_USB to the toggle button on tap and OUT_BLE on 3s hold to switch between the two.

This also guards bt_clr with a 3s hold.

Save debounce has been reduces from 60s to 5s to more reliably preserve the setting.